### PR TITLE
Non-HLA Data movement dialect 

### DIFF
--- a/tenstorrent/backend/print_metalium.py
+++ b/tenstorrent/backend/print_metalium.py
@@ -18,6 +18,10 @@ StatefulCircularBufferOperation = CBReserveBack | CBPushBack | CBPopFront | CBWa
 
 TRUE = IntegerAttr.from_int_and_width(1, 1)
 
+# TODO: currently printing API calls/func names is hardcoded, but should not vary based on whether the function is
+#     used on its own (as a statement) or used on the rhs (as an expression). Should handle this to remove a lot
+#     of the boilerplate.
+
 
 class PrintMetalium:
     """
@@ -108,14 +112,17 @@ class PrintMetalium:
                 self.print_tt_op(operation)
                 operation = operation.next_op
 
+            elif type(operation) in DataMovement.operations:
+                self.print_tt_op(operation)
+                operation = operation.next_op
+
             # skip constants on their own, will be picked up later if used
             elif type(operation) in self._skip:
                 operation = operation.next_op
                 continue
 
             else:
-                self.print(f"UNHANDLED OPERATION: {operation.__class__.__name__}")
-                break
+                raise NotImplementedError(f"Unhandled operation: {operation.__class__.__name__}")
 
 
     def print_module(self, module: ModuleOp):
@@ -248,10 +255,10 @@ class PrintMetalium:
         raise Exception(f"Unhandled type {creator.__class__} in get_value()")
 
     def print_tt_op(self, operation: StatefulCircularBufferOperation):
-        api_name = operation.name.replace('.', '_')
-        arg1 = self.get_value(operation.operands[0])
-        arg2 = self.get_value(operation.operands[1])
-        self.print(f"{api_name}({arg1}, {arg2});")
+        api_name = operation.name.replace('.', '_').replace('dm_', '')
+
+        values = [self.get_value(op) for op in operation.operands]
+        self.print(f"{api_name}({', '.join(values)});")
 
     def print(self, s: str, indented: bool = True):
         prefix = self._prefix if indented else ""

--- a/tenstorrent/backend/print_metalium.py
+++ b/tenstorrent/backend/print_metalium.py
@@ -1,4 +1,4 @@
-from xdsl.dialects.builtin import ModuleOp, IndexType, Float32Type, IntegerAttr
+from xdsl.dialects.builtin import ModuleOp, IndexType, Float32Type, IntegerAttr, i1, i32, f32
 from xdsl.dialects.func import FuncOp
 from xdsl.dialects.arith import Constant, Addi, Muli, Addf, Mulf, SignlessIntegerBinaryOperation, IndexCastOp, \
     FloatingPointLikeBinaryOperation, Cmpi, AndI, OrI, Cmpf, ComparisonOperation, XOrI, Subi, Subf, ExtFOp, Divf
@@ -69,9 +69,9 @@ class PrintMetalium:
 
         self._mlir_to_cpp_type = {
             IndexType(): "std::int32_t",
-            IntegerType(32): "std::int32_t",
-            Float32Type(): "float",
-            IntegerType(1): "bool",
+            i32: "std::int32_t",
+            f32: "float",
+            i1: "bool",
         }
 
         self._skip = [

--- a/tenstorrent/dialects/__init__.py
+++ b/tenstorrent/dialects/__init__.py
@@ -1,1 +1,2 @@
 from .circular_buffer import *
+from .data_movement import *

--- a/tenstorrent/dialects/circular_buffer.py
+++ b/tenstorrent/dialects/circular_buffer.py
@@ -1,4 +1,4 @@
-from xdsl.dialects.builtin import IntegerType
+from xdsl.dialects.builtin import i1, i32
 from xdsl.ir import SSAValue, Operation, Dialect
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
 
@@ -10,20 +10,20 @@ from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
 class CBPagesAvailableAtFront(IRDLOperation):
     name = "cb.pages_available_at_front"
 
-    cb_id = operand_def(IntegerType)      # int32_t
-    num_pages = operand_def(IntegerType)  # int32_t
-    result = result_def(IntegerType(1))   # returns a bool?
+    cb_id = operand_def(i32)
+    num_pages = operand_def(i32)
+    result = result_def(i1)
 
     def __init__(self, cb_id: SSAValue | Operation, num_pages: SSAValue | Operation):
-        super().__init__(operands=[cb_id, num_pages], result_types=[IntegerType(1)])
+        super().__init__(operands=[cb_id, num_pages], result_types=[i1])
 
 
 @irdl_op_definition
 class CBWaitFront(IRDLOperation):
     name = "cb.wait_front"
 
-    cb_id = operand_def(IntegerType)
-    num_tiles = operand_def(IntegerType)
+    cb_id = operand_def(i32)
+    num_tiles = operand_def(i32)
 
     def __init__(self, cb_id: SSAValue | Operation, num_tiles: SSAValue | Operation):
         super().__init__(operands=[cb_id, num_tiles])
@@ -33,20 +33,20 @@ class CBWaitFront(IRDLOperation):
 class CBPagesReservableAtBack(IRDLOperation):
     name = "cb.pages_reservable_at_back"
 
-    cb_id = operand_def(IntegerType)
-    num_pages = operand_def(IntegerType)
-    result = result_def(IntegerType(1))
+    cb_id = operand_def(i32)
+    num_pages = operand_def(i32)
+    result = result_def(i1)
 
     def __init__(self, cb_id: SSAValue | Operation, num_pages: SSAValue | Operation):
-        super().__init__(operands=[cb_id, num_pages], result_types=[IntegerType(1)])
+        super().__init__(operands=[cb_id, num_pages], result_types=[i1])
 
 
 @irdl_op_definition
 class CBReserveBack(IRDLOperation):
     name = "cb.reserve_back"
 
-    cb_id = operand_def(IntegerType)
-    num_tiles = operand_def(IntegerType)
+    cb_id = operand_def(i32)
+    num_tiles = operand_def(i32)
 
     def __init__(self, cb_id: SSAValue | Operation, num_tiles: SSAValue | Operation):
         super().__init__(operands=[cb_id, num_tiles])
@@ -56,8 +56,8 @@ class CBReserveBack(IRDLOperation):
 class CBPushBack(IRDLOperation):
     name = "cb.push_back"
 
-    cb_id = operand_def(IntegerType)
-    num_tiles = operand_def(IntegerType)
+    cb_id = operand_def(i32)
+    num_tiles = operand_def(i32)
 
     def __init__(self, cb_id: SSAValue | Operation, num_tiles: SSAValue | Operation):
         super().__init__(operands=[cb_id, num_tiles])
@@ -67,8 +67,8 @@ class CBPushBack(IRDLOperation):
 class CBPopFront(IRDLOperation):
     name = "cb.pop_front"
 
-    cb_id = operand_def(IntegerType)
-    num_tiles = operand_def(IntegerType)
+    cb_id = operand_def(i32)
+    num_tiles = operand_def(i32)
 
     def __init__(self, cb_id: SSAValue | Operation, num_tiles: SSAValue | Operation):
         super().__init__(operands=[cb_id, num_tiles])

--- a/tenstorrent/dialects/data_movement.py
+++ b/tenstorrent/dialects/data_movement.py
@@ -1,0 +1,193 @@
+from xdsl.dialects.builtin import IntegerType, Signedness, i1, MemRefType
+from xdsl.ir import SSAValue, Operation, Dialect
+from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def
+
+
+uint8 = IntegerType(8, signedness=Signedness.UNSIGNED)
+uint32 = IntegerType(32, signedness=Signedness.UNSIGNED)
+uint64 = IntegerType(64, signedness=Signedness.UNSIGNED)
+
+
+@irdl_op_definition
+class DMNocAsyncRead(IRDLOperation):
+    name = "dm.noc_async_read"
+
+    src_noc_address = operand_def(uint64)
+    dst_local_l1_addr = operand_def(uint32)
+    size = operand_def(uint32)
+    noc = operand_def(uint8)  # TODO: default value of noc_index?
+
+    def __init__(self,
+                 src_noc_address: SSAValue | Operation,
+                 dst_local_l1_addr: SSAValue | Operation,
+                 size: SSAValue | Operation,
+                 noc: SSAValue | Operation):
+        super().__init__(operands=[
+            src_noc_address,
+            dst_local_l1_addr,
+            size,
+            noc
+        ])
+
+
+@irdl_op_definition
+class DMNocAsyncWrite(IRDLOperation):
+    name = "dm.noc_async_write"
+
+    src_local_l1_addr = operand_def(uint32)
+    dst_noc_addr = operand_def(uint64)
+    size = operand_def(uint32)
+    noc = operand_def(uint8)
+
+    def __init__(self,
+                 src_local_l1_addr: SSAValue | Operation,
+                 dst_noc_addr: SSAValue | Operation,
+                 size: SSAValue | Operation,
+                 noc: SSAValue | Operation):
+        super().__init__(operands=[src_local_l1_addr, dst_noc_addr, size, noc])
+
+
+@irdl_op_definition
+class DMNocAsyncReadBarrier(IRDLOperation):
+    """
+    This blocking call waits for all the outstanding enqueued ``noc_async_read``
+    calls issued on the current Tensix core to complete. After returning from
+    this call the ``noc_async_read`` queue will be empty for the current Tensix
+    core.
+    """
+    name = "dm.noc_async_read_barrier"
+
+    noc = operand_def(uint8)
+
+    def __init__(self, noc: SSAValue | Operation):
+        super().__init__(operands=[noc])
+
+
+@irdl_op_definition
+class DMNocAsyncWriteBarrier(IRDLOperation):
+    name = "dm.noc_async_write_barrier"
+
+    noc = operand_def(uint8)
+
+    def __init__(self, noc: SSAValue | Operation):
+        super().__init__(operands=[noc])
+
+
+@irdl_op_definition
+class DMNocAsyncWriteMulticast(IRDLOperation):
+    name = "dm.noc_async_write_multicast"
+
+    src_local_l1_addr = operand_def(uint32)
+    dst_noc_addr_multicast = operand_def(uint64)
+    size = operand_def(uint32)
+    num_dests = operand_def(uint32)
+
+    # TODO: these arguments have default values
+    linked = operand_def(i1)
+    multicast_path_reserve = operand_def(i1)
+    noc = operand_def(uint8)
+
+    def __init__(self,
+                 src_local_l1_addr: SSAValue | Operation,
+                 dst_noc_addr_multicast: SSAValue | Operation,
+                 size: SSAValue | Operation,
+                 num_dests: SSAValue | Operation,
+                 linked: SSAValue | Operation,
+                 multicast_path_reserve: SSAValue | Operation,
+                 noc: SSAValue | Operation):
+        super().__init__(
+            operands=[
+                src_local_l1_addr,
+                dst_noc_addr_multicast,
+                size,
+                num_dests,
+                linked,
+                multicast_path_reserve,
+                noc
+            ]
+        )
+
+
+@irdl_op_definition
+class DMNocSemaphoreSetMulticast(IRDLOperation):
+    name = "dm.noc_semaphore_set_multicast"
+
+    src_local_l1_addr = operand_def(uint32)
+    dst_noc_addr_multicast = operand_def(uint64)
+    num_dests = operand_def(uint32)
+
+    # TODO: these arguments have default values
+    linked = operand_def(i1)
+    multicast_path_reserve = operand_def(i1)
+    noc = operand_def(uint8)
+
+    def __init__(self,
+                 src_local_l1_addr: SSAValue | Operation,
+                 dst_noc_addr_multicast: SSAValue | Operation,
+                 num_dests: SSAValue | Operation,
+                 linked: SSAValue | Operation,
+                 multicast_path_reserve: SSAValue | Operation,
+                 noc: SSAValue | Operation):
+        super().__init__(
+            operands=[
+                src_local_l1_addr,
+                dst_noc_addr_multicast,
+                num_dests,
+                linked,
+                multicast_path_reserve,
+                noc
+            ]
+        )
+
+
+@irdl_op_definition
+class DMNocSemaphoreSet(IRDLOperation):
+    name = "dm.noc_semaphore_set"
+
+    # volatile uint32_t *sem_addr  : is this  memref to a uint32?
+    sem_addr = operand_def(MemRefType(uint32, [1]))
+    val = operand_def(uint32)
+
+    def __init__(self, sem_addr: SSAValue | Operation, val: SSAValue | Operation):
+        super().__init__(operands=[sem_addr, val])
+
+
+@irdl_op_definition
+class DMNocSemaphoreWait(IRDLOperation):
+    name = "dm.noc_semaphore_wait"
+
+    # as above
+    sem_addr = operand_def(MemRefType(uint32, [1]))
+    val = operand_def(uint32)
+
+    def __init__(self, sem_addr: SSAValue | Operation, val: SSAValue | Operation):
+        super().__init__(operands=[sem_addr, val])
+
+
+@irdl_op_definition
+class DMNocSemaphoreInc(IRDLOperation):
+    name = "dm.noc_semaphore_inc"
+
+    addr = operand_def(uint64)
+    incr = operand_def(uint32)
+    noc_id = operand_def(uint8)
+
+    def __init__(self, addr: SSAValue | Operation, incr: SSAValue | Operation, noc_id: SSAValue | Operation):
+        super().__init__(operands=[addr, incr, noc_id])
+
+
+DataMovement = Dialect(
+    "dm",
+    [
+        DMNocAsyncRead,
+        DMNocAsyncWrite,
+        DMNocAsyncReadBarrier,
+        DMNocAsyncWriteBarrier,
+        DMNocAsyncWriteMulticast,
+        DMNocSemaphoreSetMulticast,
+        DMNocSemaphoreSet,
+        DMNocSemaphoreWait,
+        DMNocSemaphoreInc
+    ],
+    []
+)

--- a/tenstorrent/dialects/data_movement.py
+++ b/tenstorrent/dialects/data_movement.py
@@ -160,6 +160,7 @@ class DMNocSemaphoreWait(IRDLOperation):
     sem_addr = operand_def(MemRefType(uint32, [1]))
     val = operand_def(uint32)
 
+    # TODO: add MLIR validation, and use memref in place of memref.load for certain args somehow
     def __init__(self, sem_addr: SSAValue | Operation, val: SSAValue | Operation):
         super().__init__(operands=[sem_addr, val])
 

--- a/tenstorrent/frontend/__init__.py
+++ b/tenstorrent/frontend/__init__.py
@@ -1,2 +1,1 @@
 from .decorators import data_in
-from .dummy import *

--- a/tenstorrent/frontend/dummy.py
+++ b/tenstorrent/frontend/dummy.py
@@ -1,5 +1,3 @@
-
-
 # Circular buffer dialect
 def cb_pages_available_at_front(cb_id: int, num_pages: int) -> bool:
     pass
@@ -22,4 +20,58 @@ def cb_push_back(cb_id: int, num_tiles: int):
 
 
 def cb_pop_front(cb_id: int, num_tiles: int):
+    pass
+
+
+# Data movement dialect
+def noc_async_read(src_noc_addr: int, dst_local_l1_addr: int, size: int, noc: int):
+    pass
+
+
+def noc_async_write(src_local_l1_addr: int, dst_noc_addr: int, size: int, noc: int):
+    pass
+
+
+def noc_async_read_barrier(noc: int):
+    pass
+
+
+def noc_async_write_barrier(noc: int):
+    pass
+
+
+def noc_async_write_multicast(
+        src_local_l1_addr: int,
+        dst_noc_addr_multicast: int,
+        size: int,
+        num_dests: int,
+        noc: int,
+        linked: bool = False,
+        multicast_path_reserve: bool = True,
+):
+    pass
+
+
+def noc_semaphore_set_multicast(
+        src_local_l1_addr: int,
+        dst_noc_addr_multicast: int,
+        num_dests: int,
+        noc: int,
+        linked: bool = False,
+        multicast_path_reserve: bool = True,
+):
+    pass
+
+
+# TODO: this api may benefit from high level Semaphore() class as uses pointers to addresses
+def noc_semaphore_set(sem_addr: int, val: int):
+    pass
+
+
+# and this
+def noc_semaphore_wait(sem_addr: int, val: int):
+    pass
+
+
+def noc_semaphore_inc(addr: int, incr: int, noc_id: int):
     pass

--- a/tenstorrent/frontend/type_checker.py
+++ b/tenstorrent/frontend/type_checker.py
@@ -24,6 +24,15 @@ class TypeChecker(ast.NodeVisitor):
             cb_reserve_back.__name__: NoneType(),
             cb_pages_available_at_front.__name__: IntegerType(1),
             cb_pages_reservable_at_back.__name__: IntegerType(1),
+            noc_semaphore_set.__name__: NoneType(),
+            noc_semaphore_set_multicast.__name__: NoneType(),
+            noc_async_write_multicast.__name__: NoneType(),
+            noc_async_write.__name__: NoneType(),
+            noc_async_read.__name__: NoneType(),
+            noc_semaphore_inc.__name__: NoneType(),
+            noc_semaphore_wait.__name__: NoneType(),
+            noc_async_read_barrier.__name__: NoneType(),
+            noc_async_write_barrier.__name__: NoneType(),
         }
 
     def generic_visit(self, node):

--- a/tests/data_in.py
+++ b/tests/data_in.py
@@ -1,7 +1,6 @@
 import tenstorrent as tt
-from tenstorrent.frontend import (cb_push_back, cb_wait_front,
-                                  cb_pop_front, cb_pages_available_at_front,
-                                  cb_reserve_back, cb_pages_reservable_at_back)
+from tenstorrent.frontend.dummy import *
+
 
 @tt.data_in
 def single_assignment():
@@ -226,6 +225,27 @@ def adv_arg_eval():
         d = cb_pages_reservable_at_back(a, i)
 
 
+@tt.data_in
+def call_noc_funcs():
+    a = 1
+    b = 2
+    c = 3
+    d = 4
+    e = 5
+    f = False
+    g = True
+
+    noc_async_write_multicast(a, b, c, d, e, f, g)
+    noc_semaphore_set_multicast(a, b, c, d, f, g)
+    noc_async_write(a, b, c, d)
+    noc_async_read(a, b, c, d)
+    noc_semaphore_set(a, b)
+    noc_semaphore_wait(a, b)
+    noc_semaphore_inc(a, b, c)
+    noc_async_read_barrier(a)
+    noc_async_write_barrier(a)
+
+
 # Constructs currently implemented:
 #   - assignment
 #   - ints, floats, mixed
@@ -273,3 +293,4 @@ division()
 bool_assign()
 func_call()
 adv_arg_eval()
+call_noc_funcs()

--- a/tests/results/call_noc_funcs.cpp
+++ b/tests/results/call_noc_funcs.cpp
@@ -1,0 +1,25 @@
+void call_noc_funcs() {
+    std::int32_t a;
+    a = 1;
+    std::int32_t a1;
+    a1 = 2;
+    std::int32_t a2;
+    a2 = 3;
+    std::int32_t a3;
+    a3 = 4;
+    std::int32_t a4;
+    a4 = 5;
+    bool a5;
+    a5 = false;
+    bool a6;
+    a6 = true;
+    noc_async_write_multicast(a, a1, a2, a3, a5, a6, a4);
+    noc_semaphore_set_multicast(a, a1, a2, a5, a6, a3);
+    noc_async_write(a, a1, a2, a3);
+    noc_async_read(a, a1, a2, a3);
+    noc_semaphore_set(a, a1);
+    noc_semaphore_wait(a, a1);
+    noc_semaphore_inc(a, a1, a2);
+    noc_async_read_barrier(a);
+    noc_async_write_barrier(a);
+}

--- a/tests/results/call_noc_funcs.mlir
+++ b/tests/results/call_noc_funcs.mlir
@@ -1,0 +1,64 @@
+builtin.module {
+  func.func @call_noc_funcs() {
+    %0 = arith.constant 1 : i32
+    %1 = memref.alloc() : memref<1xi32>
+    memref.store %0, %1[] : memref<1xi32>
+    %2 = arith.constant 2 : i32
+    %3 = memref.alloc() : memref<1xi32>
+    memref.store %2, %3[] : memref<1xi32>
+    %4 = arith.constant 3 : i32
+    %5 = memref.alloc() : memref<1xi32>
+    memref.store %4, %5[] : memref<1xi32>
+    %6 = arith.constant 4 : i32
+    %7 = memref.alloc() : memref<1xi32>
+    memref.store %6, %7[] : memref<1xi32>
+    %8 = arith.constant 5 : i32
+    %9 = memref.alloc() : memref<1xi32>
+    memref.store %8, %9[] : memref<1xi32>
+    %10 = arith.constant false
+    %11 = memref.alloc() : memref<1xi1>
+    memref.store %10, %11[] : memref<1xi1>
+    %12 = arith.constant true
+    %13 = memref.alloc() : memref<1xi1>
+    memref.store %12, %13[] : memref<1xi1>
+    %14 = memref.load %1[] : memref<1xi32>
+    %15 = memref.load %3[] : memref<1xi32>
+    %16 = memref.load %5[] : memref<1xi32>
+    %17 = memref.load %7[] : memref<1xi32>
+    %18 = memref.load %9[] : memref<1xi32>
+    %19 = memref.load %11[] : memref<1xi1>
+    %20 = memref.load %13[] : memref<1xi1>
+    "dm.noc_async_write_multicast"(%14, %15, %16, %17, %19, %20, %18) : (i32, i32, i32, i32, i1, i1, i32) -> ()
+    %21 = memref.load %1[] : memref<1xi32>
+    %22 = memref.load %3[] : memref<1xi32>
+    %23 = memref.load %5[] : memref<1xi32>
+    %24 = memref.load %7[] : memref<1xi32>
+    %25 = memref.load %11[] : memref<1xi1>
+    %26 = memref.load %13[] : memref<1xi1>
+    "dm.noc_semaphore_set_multicast"(%21, %22, %23, %25, %26, %24) : (i32, i32, i32, i1, i1, i32) -> ()
+    %27 = memref.load %1[] : memref<1xi32>
+    %28 = memref.load %3[] : memref<1xi32>
+    %29 = memref.load %5[] : memref<1xi32>
+    %30 = memref.load %7[] : memref<1xi32>
+    "dm.noc_async_write"(%27, %28, %29, %30) : (i32, i32, i32, i32) -> ()
+    %31 = memref.load %1[] : memref<1xi32>
+    %32 = memref.load %3[] : memref<1xi32>
+    %33 = memref.load %5[] : memref<1xi32>
+    %34 = memref.load %7[] : memref<1xi32>
+    "dm.noc_async_read"(%31, %32, %33, %34) : (i32, i32, i32, i32) -> ()
+    %35 = memref.load %1[] : memref<1xi32>
+    %36 = memref.load %3[] : memref<1xi32>
+    "dm.noc_semaphore_set"(%35, %36) : (i32, i32) -> ()
+    %37 = memref.load %1[] : memref<1xi32>
+    %38 = memref.load %3[] : memref<1xi32>
+    "dm.noc_semaphore_wait"(%37, %38) : (i32, i32) -> ()
+    %39 = memref.load %1[] : memref<1xi32>
+    %40 = memref.load %3[] : memref<1xi32>
+    %41 = memref.load %5[] : memref<1xi32>
+    "dm.noc_semaphore_inc"(%39, %40, %41) : (i32, i32, i32) -> ()
+    %42 = memref.load %1[] : memref<1xi32>
+    "dm.noc_async_read_barrier"(%42) : (i32) -> ()
+    %43 = memref.load %1[] : memref<1xi32>
+    "dm.noc_async_write_barrier"(%43) : (i32) -> ()
+  }
+}


### PR DESCRIPTION
This dialect will benefit from higher-level abstractions in Python, such as a `NoC()` and `SemaphoreAddress()`. Currently works but produces invalid MLIR as `dm.noc_semaphore_set` and `dm.noc_seamphore_wait` require the address of a semaphore but Python only has integers