### PR TITLE
Nick

### DIFF
--- a/tenstorrent/backend/print_metalium.py
+++ b/tenstorrent/backend/print_metalium.py
@@ -1,18 +1,18 @@
 from xdsl.dialects.builtin import ModuleOp, IndexType, Float32Type, IntegerAttr, i1, i32, f32
-from xdsl.dialects.func import FuncOp
-from xdsl.dialects.arith import Constant, Addi, Muli, Addf, Mulf, SignlessIntegerBinaryOperation, IndexCastOp, \
-    FloatingPointLikeBinaryOperation, Cmpi, AndI, OrI, Cmpf, ComparisonOperation, XOrI, Subi, Subf, ExtFOp, Divf
-from xdsl.dialects.scf import For, Yield, If, While
-from xdsl.dialects.memref import Alloc, Store, Load
+from xdsl.dialects.func import FuncOp, ReturnOp
+from xdsl.dialects.arith import ConstantOp, AddiOp, MuliOp, AddfOp, MulfOp, SignlessIntegerBinaryOperation, IndexCastOp, \
+    FloatingPointLikeBinaryOperation, CmpiOp, AndIOp, OrIOp, CmpfOp, ComparisonOperation, XOrIOp, SubiOp, SubfOp, ExtFOp, DivfOp
+from xdsl.dialects.scf import ForOp, YieldOp, IfOp, WhileOp
+from xdsl.dialects.memref import AllocOp, StoreOp, LoadOp
 from xdsl.ir import Block, Region, OpResult
 
-from tenstorrent.dialects import *
+from dialects import *
 
 
 ArithmeticOperation = SignlessIntegerBinaryOperation | FloatingPointLikeBinaryOperation
-BooleanOperation = AndI | OrI | Cmpi | Cmpf
+BooleanOperation = AndIOp | OrIOp | CmpiOp | CmpfOp
 BinaryOperation = ArithmeticOperation | BooleanOperation
-OpWithBody = FuncOp | For | While
+OpWithBody = FuncOp | ForOp | WhileOp
 CircularBufferOperationWithResult = CBPagesAvailableAtFront | CBPagesReservableAtBack
 StatefulCircularBufferOperation = CBReserveBack | CBPushBack | CBPopFront | CBWaitFront
 
@@ -32,16 +32,16 @@ class PrintMetalium:
         self._file = file
         self._names = {}  # SSAVal -> Variable Name
         self._op_to_sym = {
-            Addi: "+",
-            Muli: "*",
-            Addf: "+",
-            Mulf: "*",
-            AndI: "&&",
-            OrI: "||",
-            XOrI: "^",
-            Subi: "-",
-            Subf: "-",
-            Divf: "/",
+            AddiOp: "+",
+            MuliOp: "*",
+            AddfOp: "+",
+            MulfOp: "*",
+            AndIOp: "&&",
+            OrIOp: "||",
+            XOrIOp: "^",
+            SubiOp: "-",
+            SubfOp: "-",
+            DivfOp: "/",
         }
 
         self._int_comparison_ops = {
@@ -79,56 +79,59 @@ class PrintMetalium:
         }
 
         self._skip = [
-            Constant, Alloc, Load, Addi, Muli, Addf, Mulf, IndexCastOp, Yield,
-            Cmpi, AndI, OrI, XOrI, Subi, Subf, ExtFOp, Divf,
+            ConstantOp, AllocOp, LoadOp, AddiOp, MuliOp, AddfOp, MulfOp, IndexCastOp, YieldOp,
+            CmpiOp, AndIOp, OrIOp, XOrIOp, SubiOp, SubfOp, ExtFOp, DivfOp,
             CBPagesReservableAtBack, CBPagesAvailableAtFront
         ]
 
-    def print_block(self, block: Block):
-        operation = block.ops.first
-
-        while operation:
-            if isinstance(operation, FuncOp):
-                self.print_func(operation)
-                operation = operation.next_op
-
-            elif isinstance(operation, Alloc):
-                self.print_declaration(operation)
-                operation = operation.next_op
-
-            elif isinstance(operation, Store):
-                self.print_assignment(operation)
-                operation = operation.next_op
-
-            elif isinstance(operation, For):
-                self.print_for_loop(operation)
-                operation = operation.next_op
-
-            elif isinstance(operation, If):
-                self.print_if_statement(operation)
-                operation = operation.next_op
-
-            elif isinstance(operation, StatefulCircularBufferOperation):
-                self.print_tt_op(operation)
-                operation = operation.next_op
-
-            elif type(operation) in DataMovement.operations:
-                self.print_tt_op(operation)
-                operation = operation.next_op
-
-            # skip constants on their own, will be picked up later if used
-            elif type(operation) in self._skip:
-                operation = operation.next_op
-                continue
-
-            else:
-                raise NotImplementedError(f"Unhandled operation: {operation.__class__.__name__}")
-
-
-    def print_module(self, module: ModuleOp):
-        for region in module.regions:
+    def print_op(self, operation):
+        if isinstance(operation, ModuleOp):
+          for region in operation.regions:
             for block in region.blocks:
-                self.print_block(block)
+              self.print_op(block)
+
+        elif isinstance(operation, Block):
+          for op in operation.ops:
+            self.print_op(op)
+
+        elif isinstance(operation, FuncOp):
+            self.print_func(operation)
+            operation = operation.next_op
+
+        elif isinstance(operation, ReturnOp):
+          pass
+
+        elif isinstance(operation, AllocOp):
+            self.print_declaration(operation)
+            operation = operation.next_op
+
+        elif isinstance(operation, StoreOp):
+            self.print_assignment(operation)
+            operation = operation.next_op
+
+        elif isinstance(operation, ForOp):
+            self.print_for_loop(operation)
+            operation = operation.next_op
+
+        elif isinstance(operation, IfOp):
+            self.print_if_statement(operation)
+            operation = operation.next_op
+
+        elif isinstance(operation, StatefulCircularBufferOperation):
+            self.print_tt_op(operation)
+            operation = operation.next_op
+
+        elif type(operation) in DataMovement.operations:
+            self.print_tt_op(operation)
+            operation = operation.next_op
+
+        # skip constants on their own, will be picked up later if used
+        elif type(operation) in self._skip:
+            operation = operation.next_op
+
+        else:
+            raise NotImplementedError(f"Unhandled operation: {operation.__class__.__name__}")
+
 
     def print_func(self, func: FuncOp):
         """
@@ -144,7 +147,7 @@ class PrintMetalium:
 
         self.print("}")
 
-    def print_for_loop(self, loop: For):
+    def print_for_loop(self, loop: ForOp):
         # we know the first operation in the loop should be the store into i
         store_i = loop.body.block.first_op
         i_loop_ssa = store_i.operands[0]
@@ -166,11 +169,11 @@ class PrintMetalium:
 
     def print_region(self, body: Region):
         for block in body.blocks:
-            self.print_block(block)
+            self.print_op(block)
 
 
-    def print_declaration(self, op: Alloc):
-        index = isinstance(op.next_op, For)
+    def print_declaration(self, op: AllocOp):
+        index = isinstance(op.next_op, ForOp)
         var_name = self.create_fresh_variable(hint='i' if index else 'a')
         type_decl = self._mlir_to_cpp_type[op.result_types[0].element_type]
 
@@ -180,7 +183,7 @@ class PrintMetalium:
         self._names[ssa_referring_to_var] = var_name
 
 
-    def print_assignment(self, op: Store):
+    def print_assignment(self, op: StoreOp):
         # memref.store value, destination[]
         ssa_value = op.operands[0]
         ssa_destination = op.operands[1]
@@ -191,7 +194,7 @@ class PrintMetalium:
         self.print(f"{var_name} = {result};")
 
 
-    def print_if_statement(self, op: If):
+    def print_if_statement(self, op: IfOp):
         self.print(f"if ({self.get_value(op.cond)}) {'{'}")
 
         self._indent += 1
@@ -232,7 +235,7 @@ class PrintMetalium:
             return self._names[ssa_value]
 
         creator = ssa_value.owner
-        if isinstance(creator, Constant):
+        if isinstance(creator, ConstantOp):
             return str(creator.value.value.data).lower()
 
         if isinstance(creator, IndexCastOp):
@@ -244,7 +247,7 @@ class PrintMetalium:
         if isinstance(creator, BinaryOperation):
             return self.binary_op_string(creator)
 
-        if isinstance(creator, Load):
+        if isinstance(creator, LoadOp):
             return self.get_value(creator.operands[0])
 
         if isinstance(creator, CircularBufferOperationWithResult):
@@ -292,13 +295,13 @@ class PrintMetalium:
             assert isinstance(operand, OpResult)
             creator = operand.op
 
-            if isinstance(creator, Constant):
+            if isinstance(creator, ConstantOp):
                 values[i] = creator.value.value.data
 
             elif isinstance(creator, ExtFOp):
                 values[i] = "static_cast<float>(" + self.get_value(creator.operands[0]) + ")"
 
-            elif isinstance(creator, Load):
+            elif isinstance(creator, LoadOp):
                 values[i] = self._names[creator.operands[0]]
 
             elif isinstance(creator, ArithmeticOperation):

--- a/tenstorrent/dialects/__init__.py
+++ b/tenstorrent/dialects/__init__.py
@@ -1,2 +1,3 @@
 from .circular_buffer import *
 from .data_movement import *
+from .host import *

--- a/tenstorrent/dialects/host.py
+++ b/tenstorrent/dialects/host.py
@@ -1,0 +1,34 @@
+from xdsl.dialects.builtin import IntegerType, Signedness, i32, MemRefType
+from xdsl.ir import SSAValue, Operation, Dialect, ParametrizedAttribute, TypeAttribute, OpResult
+from xdsl.ir.core import Attribute
+from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def, irdl_attr_definition
+
+@irdl_attr_definition
+class CoreCoord(ParametrizedAttribute, TypeAttribute):
+    name = "tthost.corecoord"
+
+@irdl_op_definition
+class TTHostCore(IRDLOperation):
+    name = "tthost.core"
+
+    src_noc_x = operand_def(i32)
+    src_noc_y = operand_def(i32)
+    res: OpResult = result_def(Attribute)
+
+    def __init__(self,
+                 src_noc_x: SSAValue | Operation,
+                 src_noc_y: SSAValue | Operation):
+        super().__init__(operands=[
+            src_noc_x,
+            src_noc_y],
+          result_types=[CoreCoord()])
+
+TTHost = Dialect(
+    "tthost",
+    [
+        TTHostCore,
+    ],
+    [
+        CoreCoord,
+    ],
+)

--- a/tenstorrent/frontend/memref_context.py
+++ b/tenstorrent/frontend/memref_context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 
-from xdsl.dialects.memref import Alloc
+from xdsl.dialects.memref import AllocOp
 
 
 @dataclass
@@ -18,7 +18,7 @@ class MemrefContext:
     dictionary: Dict[str, Alloc] = field(default_factory=dict)
     parent_scope: Optional[MemrefContext] = None
 
-    def __getitem__(self, identifier: str) -> Optional[Alloc]:
+    def __getitem__(self, identifier: str) -> Optional[AllocOp]:
         """Check if the given identifier is in the current scope, or a parent scope"""
         mem_location = self.dictionary.get(identifier, None)
         if mem_location:
@@ -28,7 +28,7 @@ class MemrefContext:
         else:
             return None
 
-    def __setitem__(self, identifier: str, alloc: Alloc):
+    def __setitem__(self, identifier: str, alloc: AllocOp):
         """Relate the given identifier and SSA value in the current scope"""
         self.dictionary[identifier] = alloc
 

--- a/tenstorrent/frontend/python_to_mlir.py
+++ b/tenstorrent/frontend/python_to_mlir.py
@@ -117,7 +117,7 @@ class PythonToMLIR(ast.NodeVisitor):
             operations.extend(ops)
 
         # after all processing is done, wrap in module operation
-        self.operations = builtin.ModuleOp(operations)
+        self.operations = builtin.ModuleOp(operations, {"kernel_type": builtin.StringAttr("data_in")})
         return [self.operations]
 
     def visit_FunctionDef(self, node) -> List[Operation]:

--- a/tenstorrent/frontend/python_to_mlir.py
+++ b/tenstorrent/frontend/python_to_mlir.py
@@ -10,6 +10,7 @@ from xdsl.irdl import IRDLOperation
 from .memref_context import MemrefContext
 from .type_checker import MLIRType
 from .dummy import *
+from xdsl.utils.hints import isa
 from tenstorrent.utils import flatten, remove_duplicates, subtract
 from tenstorrent.dialects import *
 
@@ -93,9 +94,6 @@ class PythonToMLIR(ast.NodeVisitor):
     def get_type(self, variable_name: str):
         return self.type_checker.types[variable_name]
 
-    def visit(self, node: ast.AST | ast.stmt | ast.expr) -> List[Operation]:
-        return [ob for ob in flatten(super().visit(node))]
-
     def get_operation(self, node) -> type:
         assert isinstance(node, ast.BinOp)
         t = self.type_checker.visit(node)
@@ -134,8 +132,8 @@ class PythonToMLIR(ast.NodeVisitor):
         self.operations = operations
 
         for child in node.body:
-            ops = self.visit(child)
-            operations.extend(ops)
+            ops, ssa = self.visit(child)
+            operations+=ops
 
         operations.append(func.ReturnOp())
 
@@ -159,9 +157,8 @@ class PythonToMLIR(ast.NodeVisitor):
 
     def visit_Assign(self, node) -> List[Operation]:
         # visit RHS, e.g. Constant in 'a = 0'
-        rhs = self.visit(node.value)
-        rhs_val = rhs[-1].results[0]
-        operations = rhs
+        rhs_ops, rhs_ssa_val = self.visit(node.value)
+        operations = rhs_ops
 
         # get the variable name to store the result in
         dest = node.targets[0]
@@ -175,49 +172,57 @@ class PythonToMLIR(ast.NodeVisitor):
 
         # if the types don't match we need to insert a cast operation
         target_type = self.type_checker.types[var_name]
-        if target_type != rhs_val.type:
-            cast = self.get_cast(target_type, rhs_val)
-            rhs_val = cast.results[0]
-            operations += [cast]
+        if target_type != rhs_ssa_val.type:
+            cast_ops, cast_ssa = self.get_cast(target_type, rhs_ssa_val)
+            if len(cast_ops) > 0:
+              assert cast_ssa is not None
+              rhs_ssa_val = cast_ssa
+              operations += cast_ops
+            else:
+              assert cast_ssa is None
 
         if not seen:
             operations += [location]
 
         # store result in that memref
-        store = memref.StoreOp.get(rhs_val, location, [])
+        store = memref.StoreOp.get(rhs_ssa_val, location, [])
 
-        return operations + [store]
+        return operations + [store], location
 
     def get_cast(self, target_type: MLIRType, ssa_val: SSAValue) -> Operation:
         if isinstance(ssa_val.type, IntegerType):
+            conv_op=None
             match target_type:
                 case Float32Type():
-                    return arith.ExtFOp(ssa_val, Float32Type())
+                    conv_op=arith.ExtFOp(ssa_val, Float32Type())
 
                 case IndexType():
-                    return arith.IndexCastOp(ssa_val, IndexType())
+                    conv_op=arith.IndexCastOp(ssa_val, IndexType())
+            if conv_op is not None:
+              return [conv_op], conv_op.results[0]
+        return [], None
 
-        raise NotImplementedError(f"Casting from {ssa_val.type.__class__.__name__} "
-                                  f"to {target_type.__class__.__name__}")
 
-
-    def visit_Constant(self, node) -> List[Operation]:
+    def visit_Constant(self, node):
         data = node.value
 
+        arith_op=None
+
         if isinstance(data, bool):
-            return [arith.ConstantOp(IntegerAttr(data, IntegerType(1)))]
+            arith_op = arith.ConstantOp(IntegerAttr(data, IntegerType(1)))
+        elif isinstance(data, int):
+            arith_op = arith.ConstantOp(IntegerAttr(data, IntegerType(32)))
+        elif isinstance(data, float):
+            arith_op = arith.ConstantOp(FloatAttr(data, Float32Type()))
 
-        if isinstance(data, int):
-            return [arith.ConstantOp(IntegerAttr(data, IntegerType(32)))]
+        if arith_op is None:
+          raise Exception(f"Unhandled constant type: {data.__class__.__name__}")
 
-        if isinstance(data, float):
-            return [arith.ConstantOp(FloatAttr(data, Float32Type()))]
-
-        raise Exception(f"Unhandled constant type: {data.__class__.__name__}")
+        return [arith_op], arith_op.results[0]
 
     def visit_BinOp(self, node: ast.BinOp) -> List[Operation]:
-        lhs = self.visit(node.left)
-        rhs = self.visit(node.right)
+        lhs_ops, lhs_ssa_val = self.visit(node.left)
+        rhs_ops, rhs_ssa_val = self.visit(node.right)
 
         # need to insert operations at evaluation order:
         for op in lhs + rhs:
@@ -226,77 +231,73 @@ class PythonToMLIR(ast.NodeVisitor):
 
         operations = []
 
-        # get references to the SSA values
-        l_val: OpResult = lhs[-1].results[0]
-        r_val: OpResult = rhs[-1].results[0]
-
         # if types differ, we need to cast for the operation
-        if l_val.type != r_val.type:
-            target_type = self.type_checker.dominating_type(l_val.type, r_val.type)
-            if l_val.type != target_type:
-                l_cast = self.get_cast(target_type, l_val)
+        if lhs_ssa_val.type != rhs_ssa_val.type:
+            target_type = self.type_checker.dominating_type(lhs_ssa_val.type, rhs_ssa_val.type)
+            if lhs_ssa_val.type != target_type:
+                l_cast = self.get_cast(target_type, lhs_ssa_val)
                 operations += [l_cast]
-                l_val = l_cast.results[0]
+                lhs_ssa_val = l_cast.results[0]
 
-            if r_val.type != target_type:
-                r_cast = self.get_cast(target_type, r_val)
+            if rhs_ssa_val.type != target_type:
+                r_cast = self.get_cast(target_type, rhs_ssa_val)
                 operations += [r_cast]
-                r_val = r_cast.results[0]
+                rhs_ssa_val = r_cast.results[0]
 
         # special case: if we have a division, we also want to cast
         if isinstance(node, ast.Div):
             target_type = Float32Type()
-            if l_val.type != target_type:
-                l_cast = self.get_cast(target_type, l_val)
+            if lhs_ssa_val.type != target_type:
+                l_cast = self.get_cast(target_type, lhs_ssa_val)
                 operations += [l_cast]
-                l_val = l_cast.results[0]
+                lhs_ssa_val = l_cast.results[0]
 
-            if r_val.type != target_type:
-                r_cast = self.get_cast(target_type, r_val)
+            if rhs_ssa_val.type != target_type:
+                r_cast = self.get_cast(target_type, rhs_ssa_val)
                 operations += [r_cast]
-                r_val = r_cast.results[0]
+                rhs_ssa_val = r_cast.results[0]
 
         op_constructor = self.get_operation(node)
-        return operations + [op_constructor(
-            l_val,
-            r_val,
+        bin_op=op_constructor(
+            lhs_ssa_val,
+            rhs_ssa_val,
             None
-        )]
+        )
+        return operations + [bin_op], bin_op.results[0]
 
     def visit_Name(self, node: ast.Name) -> List[Operation]:
         from_location = self.symbol_table[node.id]
         load = memref.Load.get(from_location, [])
-        return [load]
+        return [load], load.results[0]
 
 
     def visit_If(self, node: ast.If) -> List[Operation]:
         allocations = self.allocate_new_variables(node)
         body_ops = self.generate_body_ops(node)
 
-        condition_expr = self.visit(node.test)
-        condition = condition_expr.pop()
+        condition_expr_ops, condition_ssa_val = self.visit(node.test)
 
-        or_else = None
-        if node.orelse:
-            if isinstance(node.orelse[0], ast.If):
-                or_else = self.visit_If(node.orelse[0])
-            else:
-                or_else = []
-                for stmt in node.orelse:
-                    or_else += self.visit(stmt)
+        #or_else = None
+        #if node.orelse:
+        #    if isinstance(node.orelse[0], ast.If):
+        #        or_else_ops, or_else_ssa_val = self.visit_If(node.orelse[0])
+        #    else:
+        #        or_else = []
+        #        for stmt in node.orelse:
+        #            or_else += self.visit(stmt)
 
         # condition: SSAValue | Operation
         # return_types: Sequence[Attribute],
         # true_region: Region | Sequence[Block] | Sequence[Operation]
         # false_region: Region | Sequence[Block] | Sequence[Operation]
         if_statement = scf.If(
-            condition,
+            condition_ssa_val,
             [],
             body_ops,
-            or_else
+            [] #or_else
         )
 
-        return allocations + condition_expr + [condition, if_statement]
+        return allocations + condition_expr_ops + [condition, if_statement], if_statement.results[0]
 
 
     def visit_Compare(self, node) -> List[Operation]:
@@ -310,7 +311,7 @@ class PythonToMLIR(ast.NodeVisitor):
         op = self._uint_comparison[type(node.ops[0])]
         operation = arith.Cmpi(l_val, r_val, op)
 
-        return [left, right, operation]
+        return [left, right, operation], operation.results[0]
 
 
     def visit_For(self, node: ast.For) -> List[Operation]:
@@ -348,14 +349,14 @@ class PythonToMLIR(ast.NodeVisitor):
         loop_body_ops = [store] + self.generate_body_ops(node) + [scf.Yield()]
         block.add_ops(loop_body_ops)
 
-        return var_allocations + [from_expr, to_expr, step, alloc, for_loop]
+        return var_allocations + [from_expr, to_expr, step, alloc, for_loop], for_loop.results[0]
 
 
     def visit_BoolOp(self, node: ast.BoolOp) -> List[Operation]:
         # leftmost evaluation first
         # if a and b or c => if (a and b) or c
-        left_ops = self.visit(node.values[0])   # a and b
-        right_ops = self.visit(node.values[1])  # c
+        lhs_ops, lhs_ssa_val = self.visit(node.values[0])   # a and b
+        rhs_ops, rhs_ssa_val = self.visit(node.values[1])  # c
 
         match type(node.op):
             case ast.And:
@@ -368,28 +369,28 @@ class PythonToMLIR(ast.NodeVisitor):
                 raise NotImplementedError(f"{node.op.__class__.__name__}")
 
         operation = op(
-            left_ops[-1].results[0],
-            right_ops[-1].results[0]
+            lhs_ssa_val,
+            rhs_ssa_val
         )
 
-        return left_ops + right_ops + [operation]
+        return lhs_ops + rhs_ops + [operation], operation.results[0]
 
     def visit_UnaryOp(self, node) -> List[Operation]:
-        expr = self.visit(node.operand)
+        expr_ops, expr_ssa_val = self.visit(node.operand)
         true_decl = arith.Constant(IntegerAttr.from_int_and_width(1, 1))
 
         match type(node.op):
             case ast.Not:
-                return expr + [
+                unary_op = arith.XOrI(expr_ssa_val, true_decl.results[0])
+                return expr_ops + [
                     true_decl,
-                    arith.XOrI(expr[-1], true_decl.results[0])
-                ]
+                    unary_op], unary_op.results[0]
             case ast.USub:
                 zero = arith.Constant(IntegerAttr(0, IntegerType(32)))
-                return expr + [
+                unary_op = arith.Subi(zero.results[0], expr_ssa_val)
+                return expr_ops + [
                     zero,
-                    arith.Subi(zero.results[0], expr[-1].results[0])
-                ]
+                    unary_op], unary_op.results[0]
             case _:
                 raise NotImplementedError(f"{node.op.__class__.__name__}")
 
@@ -397,11 +398,23 @@ class PythonToMLIR(ast.NodeVisitor):
     def visit_Expr(self, node) -> List[Operation]:
         return self.visit(node.value)
 
+    def handleCore(self, node):
+      assert len(node.args)==2
+      x_core_ops, x_core_ssa_val=self.visit(node.args[0])
+      y_core_ops, y_core_ssa_val=self.visit(node.args[1])
+
+      core_create=TTHostCore(x_core_ssa_val, y_core_ssa_val)
+      return x_core_ops+y_core_ops+[core_create], core_create.results[0]
+
 
     def visit_Call(self, node) -> List[Operation]:
-        name = node.func.id
-        if name not in self._functions:
-            raise NotImplementedError(f"Unhandled function {name}")
+        if isa(node.func, ast.Attribute):
+          name=node.func.attr
+          if name == "Core": return self.handleCore(node)
+        else:
+          name = node.func.id
+          if name not in self._functions:
+              raise NotImplementedError(f"Unhandled function {name}")
 
         # We evaluate args in Python order (programmer intention) and then swap
         # only the SSA results that are given to the operation to preserve semantics
@@ -416,7 +429,7 @@ class PythonToMLIR(ast.NodeVisitor):
                 results[3], results[4], results[5] = results[4], results[5], results[3]
 
         operation = self._functions[name](*results)
-        return operations + [operation]
+        return operations + [operation], operation.results[0]
 
 
     def generate_body_ops(self, node: NodeWithBody) -> List[Operation]:

--- a/tenstorrent/frontend/python_to_mlir.py
+++ b/tenstorrent/frontend/python_to_mlir.py
@@ -108,6 +108,9 @@ class PythonToMLIR(ast.NodeVisitor):
     def visit_Import(self, node) -> List[Operation]:
         return []
 
+    def visit_Pass(self, node) -> List[Operation]:
+        return []
+
     def visit_Module(self, node) -> List[Operation]:
         operations: List[Operation] = []
 
@@ -139,6 +142,12 @@ class PythonToMLIR(ast.NodeVisitor):
         block = Block(operations)
         region = Region(block)
 
+        fn_name=node.name
+        if decorator_name == "data_in":
+          fn_name="kernel_main"
+        elif decorator_name == "host":
+          fn_name="main"
+
         func_op=func.FuncOp(
             "kernel_main",
             FunctionType.from_lists([], []),
@@ -146,7 +155,7 @@ class PythonToMLIR(ast.NodeVisitor):
         )
 
         # return some function definition with contents
-        return [builtin.ModuleOp([func_op], {"kernel_type": builtin.StringAttr("data_in")})]
+        return [builtin.ModuleOp([func_op], {"kernel_type": builtin.StringAttr(decorator_name)})]
 
     def visit_Assign(self, node) -> List[Operation]:
         # visit RHS, e.g. Constant in 'a = 0'

--- a/tenstorrent/frontend/tt.py
+++ b/tenstorrent/frontend/tt.py
@@ -1,0 +1,34 @@
+import ast, inspect
+import sys
+from xdsl.printer import Printer
+
+from tenstorrent.frontend.python_to_mlir import PythonToMLIR
+from tenstorrent.frontend.type_checker import TypeChecker
+
+def data_in(*args, **kwargs):
+  def empty(*args):
+    pass
+
+  def compile_wrapper(func):
+    return empty
+
+  return compile_wrapper
+
+def entryPoint():
+  code_contents_handle = open(sys.argv[0],'r')
+  code_contents=code_contents_handle.read()
+
+  parsedAST = ast.parse(code_contents)
+  code_contents_handle.close()
+
+  type_checker = TypeChecker()
+  type_checker.visit(parsedAST)
+
+  tree_walker = PythonToMLIR(type_checker)
+  tree_walker.visit(parsedAST)
+
+  printer = Printer(stream=sys.stdout)
+  printer.print_op(tree_walker.operations)
+
+entryPoint()
+exit(0)

--- a/tenstorrent/frontend/type_checker.py
+++ b/tenstorrent/frontend/type_checker.py
@@ -1,9 +1,10 @@
 import ast
 from typing import Dict
-
+from xdsl.utils.hints import isa
 from xdsl.dialects.builtin import IntegerType, Float32Type, IndexType, NoneType
 
 from .dummy import *
+from tenstorrent.dialects import *
 
 
 MLIRType = IntegerType | Float32Type | IndexType | NoneType
@@ -108,11 +109,15 @@ class TypeChecker(ast.NodeVisitor):
         return self.visit(node.value)
 
     def visit_Call(self, node: ast.Call) -> MLIRType:
-        name = node.func.id
-        if name in self.types:
-            return self.types[name]
+        if isa(node.func, ast.Attribute):
+          name=node.func.attr
+          if name == "Core": return CoreCoord
+        else:
+          name = node.func.id
+          if name in self.types:
+              return self.types[name]
 
-        raise NotImplementedError(f"Unhandled call: {name}")
+          raise NotImplementedError(f"Unhandled call: {name}")
 
     # ********* Generic visits *********
     def visit_Module(self, node):

--- a/tenstorrent/frontend/type_checker.py
+++ b/tenstorrent/frontend/type_checker.py
@@ -41,6 +41,9 @@ class TypeChecker(ast.NodeVisitor):
     def visit_Import(self, node):
         pass
 
+    def visit_Pass(self, node):
+        pass
+
 
     def dominating_type(self, a, b) -> MLIRType:
         if a == b:

--- a/tenstorrent/frontend/type_checker.py
+++ b/tenstorrent/frontend/type_checker.py
@@ -38,6 +38,9 @@ class TypeChecker(ast.NodeVisitor):
     def generic_visit(self, node):
         raise Exception(f"Unhandled node type {node.__class__.__name__}")
 
+    def visit_Import(self, node):
+        pass
+
 
     def dominating_type(self, a, b) -> MLIRType:
         if a == b:

--- a/tenstorrent/tools/tt-driver.sh
+++ b/tenstorrent/tools/tt-driver.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+python3.10 $1 > output.mlir
+cat output.mlir
+echo ""
+echo "---------------------------"
+echo ""
+tt-opt output.mlir -t tt-metalium

--- a/tenstorrent/tools/tt-opt
+++ b/tenstorrent/tools/tt-opt
@@ -16,14 +16,14 @@ from backend.print_metalium import PrintMetalium
 class TTOptMain(xDSLOptMain):
 
     def register_all_passes(self):
-        super().register_all_passes()       
+        super().register_all_passes()
 
     def register_all_targets(self):
         super().register_all_targets()
 
         def _output_metalium(prog: ModuleOp, output: IO[str]):
           printer = PrintMetalium()
-          printer.print_op(prog, output)
+          printer.print_op(prog)
 
         self.available_targets["tt-metalium"] = _output_metalium
 

--- a/tenstorrent/tools/tt-opt
+++ b/tenstorrent/tools/tt-opt
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3.10
+
+import argparse
+import ast, os, glob
+from io import IOBase
+from typing import IO
+#from xdsl.ir import MLContext
+from xdsl.dialects.builtin import ModuleOp
+from pathlib import Path
+from typing import Callable, Dict, List
+from xdsl.xdsl_opt_main import xDSLOptMain
+from dialects.data_movement import DataMovement
+from dialects.circular_buffer import CircularBuffer
+from backend.print_metalium import PrintMetalium
+
+class TTOptMain(xDSLOptMain):
+
+    def register_all_passes(self):
+        super().register_all_passes()       
+
+    def register_all_targets(self):
+        super().register_all_targets()
+
+        def _output_metalium(prog: ModuleOp, output: IO[str]):
+          printer = PrintMetalium()
+          printer.print_op(prog, output)
+
+        self.available_targets["tt-metalium"] = _output_metalium
+
+    def setup_pipeline(self):
+      super().setup_pipeline()
+
+    def register_all_arguments(self, arg_parser: argparse.ArgumentParser):
+      super().register_all_arguments(arg_parser)
+
+    def register_all_dialects(self):
+        super().register_all_dialects()
+        self.ctx.load_dialect(DataMovement)
+        self.ctx.load_dialect(CircularBuffer)
+
+    @staticmethod
+    def get_passes_as_dict(
+    ) -> Dict[str, Callable[[ModuleOp], None]]:
+        """Add all passes that can be called by psy-opt in a dictionary."""
+
+        pass_dictionary = {}
+
+        passes = FtnOptMain.passes_native
+
+        for pass_function in passes:
+            pass_dictionary[pass_function.__name__.replace(
+                "_", "-")] = pass_function
+
+        return pass_dictionary
+
+    def get_passes_as_list(native=False, integrated=False) -> List[str]:
+        """Add all passes that can be called by psy-opt in a dictionary."""
+
+        pass_list = []
+
+        passes = FtnOptMain.passes_native
+
+        for pass_function in passes:
+            pass_list.append(pass_function.__name__.replace("_", "-"))
+
+        return pass_list
+
+    def register_all_frontends(self):
+        super().register_all_frontends()
+
+def __main__():
+    tt_main = TTOptMain()
+
+    #try:
+    tt_main.run()
+    #except SyntaxError as e:
+    #    print(e.get_message())
+    #    exit(0)
+    #except Exception as e:
+    #    print("Error: %s" % str(e))
+    #    exit(0)
+
+if __name__ == "__main__":
+    __main__()


### PR DESCRIPTION
Introduces `tt-opt` and various quality of life improvements.

- Tree walker now returns (List[Operation], SSAValue) for expressions
- `tt-opt`: MLIR -> Metalium
- `tt-driver.sh`: Python -> Metalium
- `tt.py` for allowing functions to just be decorated and not called for compilation
- Start of the host dialect
- Renaming, refactoring of some operations