### PR TITLE
Introduce kernel args dialect

### DIFF
--- a/tenstorrent/dialects/__init__.py
+++ b/tenstorrent/dialects/__init__.py
@@ -2,3 +2,4 @@ from .circular_buffer import *
 from .data_movement import *
 from .host import *
 from .compute import *
+from .kernel_args import *

--- a/tenstorrent/dialects/kernel_args.py
+++ b/tenstorrent/dialects/kernel_args.py
@@ -1,0 +1,35 @@
+from xdsl.dialects.builtin import IntegerType, Signedness
+from xdsl.ir import SSAValue, Operation, Dialect, TypeAttribute
+from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def, prop_def
+
+
+uint8 = IntegerType(8, signedness=Signedness.UNSIGNED)
+uint32 = IntegerType(32, signedness=Signedness.UNSIGNED)
+uint64 = IntegerType(64, signedness=Signedness.UNSIGNED)
+
+
+@irdl_op_definition
+class TTGetArgVal(IRDLOperation):
+    name = "ttkernel.get_arg_val"
+
+    T = prop_def(TypeAttribute)
+    index = operand_def(uint32)
+
+    # TODO: later use parametric datatype
+    result = result_def(uint32)
+
+    def __init__(self, dt: TypeAttribute, index: SSAValue | Operation):
+        super().__init__(
+            properties={"T": dt},
+            operands=[index],
+            result_types=[uint32]
+        )
+
+
+KernelArgs = Dialect(
+    "ttkernel",
+    [
+        TTGetArgVal
+    ],
+    []
+)

--- a/tenstorrent/tools/tt-opt
+++ b/tenstorrent/tools/tt-opt
@@ -5,6 +5,7 @@ from typing import IO
 from xdsl.dialects.builtin import ModuleOp
 from typing import Callable, Dict, List
 from xdsl.xdsl_opt_main import xDSLOptMain
+from tenstorrent.dialects.kernel_args import KernelArgs
 from tenstorrent.dialects.data_movement import DataMovement
 from tenstorrent.dialects.circular_buffer import CircularBuffer
 from tenstorrent.backend.print_metalium import PrintMetalium
@@ -34,6 +35,7 @@ class TTOptMain(xDSLOptMain):
         super().register_all_dialects()
         self.ctx.load_dialect(DataMovement)
         self.ctx.load_dialect(CircularBuffer)
+        self.ctx.load_dialect(KernelArgs)
 
     @staticmethod
     def get_passes_as_dict(


### PR DESCRIPTION
Operations for getting compile-time/run-time kernel args. Could be moved into a different shared kernel dialect with CB ops if makes sense later.