### PR TITLE
Type coercion on op instantiation

### DIFF
--- a/tenstorrent/backend/print_metalium.py
+++ b/tenstorrent/backend/print_metalium.py
@@ -368,11 +368,11 @@ class PrintMetalium:
         store_i = loop.body.block.first_op
         loop_index_name=store_i.operands[1].name_hint
 
-        self.print(f"for ({loop_index_name}=", indented=True)
+        self.print(f"for ({loop_index_name} = ", indented=True)
         self.print_expr(loop.lb)
-        self.print(f";{loop_index_name}<")
+        self.print(f"; {loop_index_name} < ")
         self.print_expr(loop.ub)
-        self.print(f";{loop_index_name}+=")
+        self.print(f"; {loop_index_name} += ")
         self.print_expr(loop.step)
         self.print(") {", end='\n')
 
@@ -411,7 +411,7 @@ class PrintMetalium:
               # Might not be correct for multi-dimensional arrays
               total_size*=s.data
             if isa(op, memref.AllocOp):
-              self.print(f"{type_decl} * {var_name} =({type_decl}*) malloc(sizeof({type_decl})*{total_size});", indented=True, end='\n')
+              self.print(f"{type_decl} * {var_name} = ({type_decl}*) malloc(sizeof({type_decl})*{total_size});", indented=True, end='\n')
               self._free_end_of_fn.append(var_name)
             elif isa(op, memref.AllocaOp):
               self.print(f"{type_decl} {var_name}[{total_size}];", indented=True, end='\n')

--- a/tenstorrent/backend/print_metalium.py
+++ b/tenstorrent/backend/print_metalium.py
@@ -46,7 +46,7 @@ ARITH_OP_TO_SYM = {
 
 SkipOps = [
             arith.ConstantOp, memref.LoadOp, arith.AddiOp, arith.MuliOp, arith.AddfOp, arith.MulfOp, arith.IndexCastOp, scf.YieldOp,
-            arith.CmpiOp, arith.AndIOp, arith.OrIOp, arith.XOrIOp, arith.SubiOp, arith.SubfOp, arith.ExtFOp, arith.DivfOp, builtin.UnrealizedConversionCastOp
+            arith.CmpiOp, arith.AndIOp, arith.OrIOp, arith.XOrIOp, arith.SubiOp, arith.SubfOp, arith.ExtFOp, arith.DivfOp, builtin.UnrealizedConversionCastOp,
             circular_buffer.CBPagesReservableAtBack, circular_buffer.CBPagesAvailableAtFront, host.TTHostCore, host.TTCreateDevice,
             host.TTCreateCBConfig, host.TTCreateCircularBuffer, circular_buffer.CBGetWritePointer,
             host.TTGetCommandQueue, host.TTCreateProgram, host.TTCreateDRAMConfig, host.TTCreateBuffer, host.TTCreateKernel, host.TTGetMemoryAddress,
@@ -259,50 +259,27 @@ class PrintMetalium:
       elif isa(expr, arith.ExtFOp):
           self.print_cast_to_float(expr)
       elif isa(expr, builtin.UnrealizedConversionCastOp):
-          self.print(expr.results[0].name_hint)
+          self.print_unrealized_conversion_cast(expr)
       elif isa(expr, arith.IndexCastOp):
           # Go directly to the operation used as an input and process this
           self.print_expr(expr.input)
-      elif isa(expr, builtin.UnrealizedConversionCastOp):
-          self.print_cast_unrealized(expr)
       elif type(expr) in TenstorrentExpr:
           self.print_tt_expr_generic(expr)
       else:
         raise NotImplementedError(f"Unhandled expression: {expr.__class__.__name__}")
 
     def print_unrealized_conversion_cast(self, op):
-      if isa(op.results[0].type, builtin.MemRefType):
-        assert op.results[0].type.element_type in MLIR_TO_CPP_TYPES
-        type_str=MLIR_TO_CPP_TYPES[op.results[0].type.element_type]
-        var_name=op.results[0].name_hint
+        if isa(op.results[0].type, builtin.MemRefType):
+            assert op.results[0].type.element_type in MLIR_TO_CPP_TYPES
+            type_str = MLIR_TO_CPP_TYPES[op.results[0].type.element_type]
+            var_name = op.results[0].name_hint
 
-        self.print(f"{type_str} * {var_name} = ({type_str}*) ", indented=True)
-        self.print_expr(op.inputs[0])
-        self.print(";", end='\n')
-        self._names[op.results[0]] = var_name
-      else:
-        assert False
+            self.print(f"{type_str} * {var_name} = ({type_str}*) ", indented=True)
+            self.print_expr(op.inputs[0])
+            self.print(";", end='\n')
+            self._names[op.results[0]] = var_name
+            return
 
-    def print_cb_get_write_pointer(self, op):
-      self.print("get_write_ptr(")
-      self.print_expr(op.cb_id)
-      self.print(")")
-
-    def print_load_variable(self, op):
-      self.print(op.memref.name_hint)
-      if len(op.indices) > 0:
-        # For now we limit ourselves to one dimensional arrays
-        assert len(op.indices) == 1
-        self.print("[")
-        self.print_expr(op.indices[0])
-        self.print("]")
-
-    def print_cast_to_float(self, op):
-        self.print("static_cast<float>(")
-        self.print_expr(op.operands[0])
-        self.print(")")
-
-    def print_cast_unrealized(self, op):
         operand = op.inputs[0]
         in_type = operand.type
         out_type = op.outputs[0].type
@@ -346,6 +323,25 @@ class PrintMetalium:
                 self.print_expr(operand)
                 self.print(")")
 
+
+    def print_cb_get_write_pointer(self, op):
+      self.print("get_write_ptr(")
+      self.print_expr(op.cb_id)
+      self.print(")")
+
+    def print_load_variable(self, op):
+      self.print(op.memref.name_hint)
+      if len(op.indices) > 0:
+        # For now we limit ourselves to one dimensional arrays
+        assert len(op.indices) == 1
+        self.print("[")
+        self.print_expr(op.indices[0])
+        self.print("]")
+
+    def print_cast_to_float(self, op):
+        self.print("static_cast<float>(")
+        self.print_expr(op.operands[0])
+        self.print(")")
 
     def print_tthost_core(self, op):
         self.print("{")

--- a/tenstorrent/dialects/data_movement.py
+++ b/tenstorrent/dialects/data_movement.py
@@ -1,4 +1,4 @@
-from xdsl.dialects.builtin import IntegerType, Signedness, i1, MemRefType, IntegerAttr, i32
+from xdsl.dialects.builtin import IntegerType, Signedness, i1, MemRefType, IntegerAttr
 from xdsl.ir import SSAValue, Operation, Dialect
 from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, result_def, prop_def, opt_operand_def
 
@@ -13,7 +13,7 @@ class DMNocAsyncRead(IRDLOperation):
 
     src_noc_address = operand_def(uint64)
     dst_local_l1_addr = operand_def(IntegerType | MemRefType)
-    size = operand_def(i32)
+    size = operand_def(uint32)
     noc = opt_operand_def(uint8)
 
     def __init__(self,
@@ -35,7 +35,7 @@ class DMNocAsyncWrite(IRDLOperation):
 
     src_local_l1_addr = operand_def(IntegerType | MemRefType)
     dst_noc_addr = operand_def(uint64)
-    size = operand_def(i32)
+    size = operand_def(uint32)
     noc = opt_operand_def(uint8)
 
     def __init__(self,

--- a/tenstorrent/frontend/python_to_mlir.py
+++ b/tenstorrent/frontend/python_to_mlir.py
@@ -368,8 +368,6 @@ class PythonToMLIR(ast.NodeVisitor):
                 assert cast_ssa is not None
                 rhs_ssa_val = cast_ssa
                 operations += cast_ops
-            else:
-                assert cast_ssa is None
 
         if isa(dest, ast.Name):
           # create a memref
@@ -410,7 +408,7 @@ class PythonToMLIR(ast.NodeVisitor):
             return [], ssa_val
 
         # TODO: not strictly correct, should check elem types and lengths
-        if target_type == MemRefType and isinstance(ssa_val.type, MemRefType):
+        if isa(target_type, MemRefType) and isa(ssa_val.type, MemRefType):
             return [], ssa_val
 
         if isinstance(ssa_val.type, IntegerType):
@@ -419,6 +417,9 @@ class PythonToMLIR(ast.NodeVisitor):
 
             elif target_type == IndexType():
                 conv_op = arith.IndexCastOp(ssa_val, IndexType())
+
+            elif target_type == IntegerType:
+                return [], ssa_val
 
             elif target_type.bitwidth == 32 and ssa_val.type.bitwidth == 32:
                 cast = builtin.UnrealizedConversionCastOp(operands=[ssa_val], result_types=[target_type])

--- a/tenstorrent/frontend/python_to_mlir.py
+++ b/tenstorrent/frontend/python_to_mlir.py
@@ -412,12 +412,10 @@ class PythonToMLIR(ast.NodeVisitor):
                 conv_op = arith.IndexCastOp(ssa_val, IndexType())
 
             elif target_type.bitwidth == 32 and ssa_val.type.bitwidth == 32:
-                cast_to_index = arith.IndexCastOp(ssa_val, IndexType())
-                cast_to_target = arith.IndexCastOp(cast_to_index.results[0], target_type)
+                cast = builtin.UnrealizedConversionCastOp(operands=[ssa_val], result_types=[target_type])
                 return [
-                    cast_to_index,
-                    cast_to_target
-                ], cast_to_target.results[0]
+                    cast
+                ], cast.results[0]
 
             else:
                 raise NotImplementedError(f"Unsupported type cast from IntegerType: {target_type}")

--- a/tenstorrent/frontend/type_checker.py
+++ b/tenstorrent/frontend/type_checker.py
@@ -6,7 +6,7 @@ from xdsl.dialects.builtin import IntegerType, Float32Type, IndexType, NoneType,
 from .dummy import *
 from tenstorrent.dialects import *
 
-MLIRType = IntegerType | Float32Type | IndexType | NoneType
+MLIRType = IntegerType | Float32Type | IndexType | MemRefType | NoneType
 
 
 def types_equal(a, b) -> bool:
@@ -216,9 +216,9 @@ class TypeChecker(ast.NodeVisitor):
         raise NotImplementedError(f"Type not in type hierarchy: {a.__class__.__name__}")
 
     def visit_List(self, node: ast.List):
-      assert len(node.elts) == 1
-      element_type=self.visit(node.elts[0])
-      return MemRefType(element_type, [])
+        assert len(node.elts) == 1
+        element_type = self.visit(node.elts[0])
+        return MemRefType(element_type, [])
 
     def visit_Constant(self, node: ast.Constant):
         data = node.value
@@ -239,7 +239,7 @@ class TypeChecker(ast.NodeVisitor):
         return self.types[node.id]
 
     def visit_Subscript(self, node: ast.Subscript):
-        return self.types[node.value.id]
+        return self.types[node.value.id].element_type
 
     def visit_Assign(self, node: ast.Assign):
         """
@@ -247,16 +247,19 @@ class TypeChecker(ast.NodeVisitor):
         already registered, if it is then verify the type.
         """
         if isa(node.targets[0], ast.Name):
-          target = node.targets[0].id
-        elif isa(node.targets[0], ast.Subscript):
-          target = node.targets[0].value.id
-        else:
-          assert False
-        expected_type = self.visit(node.value)
+            target = node.targets[0].id
+            expected_type = self.visit(node.value)
 
-        self.types[target] = expected_type if target not in self.types else (
-            self.dominating_type(self.types[target], expected_type)
-        )
+            self.types[target] = expected_type if target not in self.types else (
+                self.dominating_type(self.types[target], expected_type)
+            )
+
+        # if we are writing to an array, the array should have already been
+        # given a type as would have been declared above
+        elif isa(node.targets[0], ast.Subscript):
+            return
+        else:
+            assert False
 
     def visit_UnaryOp(self, node) -> MLIRType:
         return self.visit(node.operand)
@@ -264,6 +267,11 @@ class TypeChecker(ast.NodeVisitor):
     def visit_BinOp(self, node: ast.BinOp) -> MLIRType:
         left_type = self.visit(node.left)
         right_type = self.visit(node.right)
+
+        if (isinstance(left_type, MemRefType)
+                and isinstance(right_type, IntegerType)
+                and isinstance(node.op, ast.Mult)):
+            return MemRefType(left_type.element_type, [node.right.value])
 
         if isinstance(node.op, ast.Div):
             return Float32Type()
@@ -278,9 +286,9 @@ class TypeChecker(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> MLIRType:
         if isa(node.func, ast.Attribute):
-          name=node.func.attr
+            name = node.func.attr
         else:
-          name = node.func.id
+            name = node.func.id
         if name in self.types:
             return self.types[name]
 


### PR DESCRIPTION
Creates the operation object, then compares against expected definition via `op.get_irdel_definition` and then adds type coercions where needed with a new op object.